### PR TITLE
Remove additional comma in PIKAN params

### DIFF
--- a/jaxkan/utils/PIKAN.py
+++ b/jaxkan/utils/PIKAN.py
@@ -278,7 +278,7 @@ def get_adapt_loss(pde_loss, model, variables):
     return adaptive_loss_fn
 
 
-def train_PIKAN(model, variables, pde_loss, collocs, bc_collocs, bc_data, glob_w, lr_vals, adapt_state=True, loc_w=None, nesterov=True, num_epochs = 3001, grid_extend={0 : 3}, grid_adapt=[], , colloc_adapt={'epochs' : []}):
+def train_PIKAN(model, variables, pde_loss, collocs, bc_collocs, bc_data, glob_w, lr_vals, adapt_state=True, loc_w=None, nesterov=True, num_epochs = 3001, grid_extend={0 : 3}, grid_adapt=[], colloc_adapt={'epochs' : []}):
     '''
         Training routine for a PIKAN
         


### PR DESCRIPTION
The additional comma in PIKAN parameters generates an error while trying to import PIKAN. This is inadvertently added while fixing #1 in commit 114c2e5bb049249ca09fc79e120293a825477eda.

```python
Traceback (most recent call last):
  File "/home/dkvc/bug.py", line 1, in <module>
    from jaxkan.utils.PIKAN import *
  File "/home/dkvc/.pyenv/versions/test/lib/python3.12/site-packages/jaxkan/utils/PIKAN.py", line 281
    def train_PIKAN(model, variables, pde_loss, collocs, bc_collocs, bc_data, glob_w, lr_vals, adapt_state=True, loc_w=None, nesterov=True, num_epochs = 3001, grid_extend={0 : 3}, grid_adapt=[], , colloc_adapt={'epochs' : []}):
                                                                                                                                                                                                   ^
SyntaxError: invalid syntax

```